### PR TITLE
Change pip installation instructions to use cadquery from github

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ sudo apt install qtbase5-dev qt5-qmake
 All platforms (Windows/Mac/Linux):
 ```
 pip install git+https://github.com/jdegenstein/jmwright-CQ-Editor
-pip install --pre "cadquery>=2.2"
+pip install git+https://github.com/CadQuery/cadquery
 pip install git+https://github.com/gumyr/build123d
 ```
 


### PR DESCRIPTION
Currently cadquery also has to be from github, otherwise pip gets into a dependency hell with numpy 1 and numpy 2 being involved.

Maybe this will be fixed once cadquery-2.6 is released.